### PR TITLE
removing unnecessary sudo for check

### DIFF
--- a/debs/zabbix-check/zabbix-check-ksm/debian/control
+++ b/debs/zabbix-check/zabbix-check-ksm/debian/control
@@ -6,7 +6,7 @@ Standards-Version: 3.8.4
 
 Package: zabbix-check-ksm
 Architecture: all
-Pre-Depends: sudo, zabbix-agent
+Pre-Depends: zabbix-agent
 Depends: ucf, lsb-base
 Description: KSM monitoring script for zabbix
  Provides a script, to monitore the KSM (Kernel Samepage Merging).

--- a/debs/zabbix-check/zabbix-check-ksm/debian/postinst
+++ b/debs/zabbix-check/zabbix-check-ksm/debian/postinst
@@ -3,7 +3,6 @@
 case "$1" in
     configure)
         chmod +x /usr/sbin/zabbix_check_ksm
-        chmod 440 /etc/sudoers.d/zabbix-check-ksm
 
         # Standartcheck ob Konfig Ordner existiert und
         # in der zabbix konfig richtig steht

--- a/debs/zabbix-check/zabbix-check-ksm/debian/zabbix-check-ksm.install
+++ b/debs/zabbix-check/zabbix-check-ksm/debian/zabbix-check-ksm.install
@@ -1,6 +1,4 @@
 etc
-etc/sudoers.d
-etc/sudoers.d/zabbix-check-ksm
 etc/zabbix
 etc/zabbix/zabbix_agentd.d
 etc/zabbix/zabbix_agentd.d/userparameter_ksm.conf

--- a/debs/zabbix-check/zabbix-check-ksm/etc/sudoers.d/zabbix-check-ksm
+++ b/debs/zabbix-check/zabbix-check-ksm/etc/sudoers.d/zabbix-check-ksm
@@ -1,1 +1,0 @@
-zabbix ALL=NOPASSWD:/usr/sbin/zabbix_check_ksm

--- a/debs/zabbix-check/zabbix-check-ksm/etc/zabbix/zabbix_agentd.d/userparameter_ksm.conf
+++ b/debs/zabbix-check/zabbix-check-ksm/etc/zabbix/zabbix_agentd.d/userparameter_ksm.conf
@@ -1,1 +1,1 @@
-UserParameter=ksm[*],sudo /usr/sbin/zabbix_check_ksm $1
+UserParameter=ksm[*],/usr/sbin/zabbix_check_ksm $1

--- a/debs/zabbix-check/zabbix-check-ksm/usr/sbin/zabbix_check_ksm
+++ b/debs/zabbix-check/zabbix-check-ksm/usr/sbin/zabbix_check_ksm
@@ -1,7 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 
-value=$1
+fail_ () {
+	echo "ZBX_NOTSUPPORTED"
+	exit 1
+}
 
-cat /sys/kernel/mm/ksm/$value 2> /dev/null || echo "ZBX_NOTSUPPORTED"
+[ $# -eq 1 ] || fail_
+[ -d /sys/kernel/mm/ksm ] || fail_
+
+read value 2>/dev/null </sys/kernel/mm/ksm/$1 && printf $value || fail_
 
 exit 0


### PR DESCRIPTION
quoting from https://www.kernel.org/doc/Documentation/vm/ksm.txt
> The KSM daemon is controlled by sysfs files in /sys/kernel/mm/ksm/,
> readable by all but writable only by root

additionally:
* lower script dependencies down to use any /bin/sh, as
  there are no special needs for BASH
* kill the "useseless use of cat" and replace by shell built-ins